### PR TITLE
use https: protocol by default

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+# 2.1.1 (2016-01-01)
+
+* use https: protocol by default
+  - segment script is loaded from a secure request if current protocol is not http: (for chrome-extension: for example)
+
 # 2.1.0 (2015-10-27)
 
 * add reset method
@@ -18,4 +23,3 @@
 # 1.0.0 (2015-01-29)
 
   * initial
-

--- a/index.js
+++ b/index.js
@@ -63,8 +63,8 @@ function load(opts) {
     var script = document.createElement('script');
     script.type = 'text/javascript';
     script.async = true;
-    script.src = ('https:' === document.location.protocol
-      ? 'https://' : 'http://')
+    script.src = ('http:' === document.location.protocol
+      ? 'http://' : 'https://')
       + 'cdn.segment.com/analytics.js/v1/'
       + key + '/analytics.min.js';
 
@@ -86,6 +86,6 @@ function load(opts) {
   if (!opts.skipPageCall) {
     analytics.page();
   }
-  
+
   return analytics;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "analytics.js-loader",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Asynchronously load segment.com analytics.js with an npm module",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
segment script is loaded from a secure request if current protocol is
not http: (for chrome-extension: for example)
